### PR TITLE
Fix piece creation edge cases

### DIFF
--- a/tetris/pieces.py
+++ b/tetris/pieces.py
@@ -11,6 +11,8 @@ class TetrominoType(Enum):
 
 class Piece:
     def __init__(self, tetromino_type):
+        if tetromino_type is None or not isinstance(tetromino_type, TetrominoType):
+            raise ValueError("Invalid tetromino type")
         self.type = tetromino_type
         # For demonstration, store a shape as a list of coordinates or something similar
         # e.g., for an I piece, a simple placeholder could be:


### PR DESCRIPTION
Fixes #4

Add validation for invalid tetromino types in `Piece` class.

* Raise `ValueError` in `Piece` class `__init__` method if `tetromino_type` is `None` or not an instance of `TetrominoType`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Orodruin-org/copilot-tdd-exercise/pull/5?shareId=0ecfe07c-0d8c-453a-987f-71a0231ab576).